### PR TITLE
[feature] NJT-39 ノートの編集機能の実装＆Toastの実装

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
 import './globals.css';
 import Providers from '@/components/Providers';
+import { Toaster } from 'sonner';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -18,8 +19,10 @@ export default function RootLayout({
   return (
     <html lang="ja">
       <body className={inter.className}>
-        {/* 2. アプリ全体をProvidersでラップする */}
-        <Providers>{children}</Providers>
+        <Providers>
+          {children}
+          <Toaster richColors />
+        </Providers>
       </body>
     </html>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "next": "15.3.4",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "sonner": "^2.0.6",
         "tailwind-merge": "^3.3.1"
       },
       "devDependencies": {
@@ -6015,6 +6016,16 @@
       "optional": true,
       "dependencies": {
         "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.6.tgz",
+      "integrity": "sha512-yHFhk8T/DK3YxjFQXIrcHT1rGEeTLliVzWbO0xN8GberVun2RiBnxAjXAYpZrqwEVHBG9asI/Li8TAAhN9m59Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map-js": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "next": "15.3.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "sonner": "^2.0.6",
     "tailwind-merge": "^3.3.1"
   },
   "devDependencies": {


### PR DESCRIPTION
### 【チケット番号】
Closes NJT-39

### 【概要】
ノートの編集機能の実装
各種成功・失敗メッセージを表示するトーストを実装

### 【修正内容】
- API側のPUTはすでに実装済みだったため、フロント側の実装を行った
- 編集状態を制御するための状態を定義した
- `noteId`を制御フラグとし、画面の切り替えを行うように実装を行った
- 各種ハンドラーの実装
- これまでのアクション（追加・削除）も含め、各アクションの成功時・失敗時にトースト表示がされるようにした