### PR TITLE
[refactor] NJT-41 初期ページのサーバーコンポーネント化＆初回フェッチ効率化

### DIFF
--- a/app/NoteContainer.tsx
+++ b/app/NoteContainer.tsx
@@ -1,0 +1,51 @@
+// app/NoteContainer.tsx
+'use client';
+
+import { NewNoteForm } from '@/components/notes/NewNoteForm';
+import { Note, useNotes } from './hooks/useNotes';
+import { NoteCard } from '@/components/notes/NoteCard';
+
+type NoteContainerProps = {
+  initialNotes: Note[];
+};
+
+export const NoteContainer = ({ initialNotes }: NoteContainerProps) => {
+  const {
+    notes,
+    isLoading,
+    isError,
+    addNote,
+    isAdding,
+    updateNote,
+    isUpdating,
+    deleteNote,
+    isDeleting,
+  } = useNotes(initialNotes);
+
+  if (isLoading) return <div className="text-center p-10">読み込み中...</div>;
+  if (isError)
+    return (
+      <div className="text-center p-10 text-red-500">
+        エラーが発生しました。
+      </div>
+    );
+
+  return (
+    <>
+      <NewNoteForm addNote={addNote} isAdding={isAdding} />
+
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        {notes?.map((note) => (
+          <NoteCard
+            key={note.id}
+            note={note}
+            updateNote={updateNote}
+            isUpdating={isUpdating}
+            deleteNote={deleteNote}
+            isDeleting={isDeleting}
+          />
+        ))}
+      </div>
+    </>
+  );
+};

--- a/app/hooks/useNotes.ts
+++ b/app/hooks/useNotes.ts
@@ -50,7 +50,7 @@ const deleteNote = async (noteId: number) => {
 };
 
 // カスタムフック本体
-export const useNotes = () => {
+export const useNotes = (initialNotes?: Note[]) => {
   const queryClient = useQueryClient();
 
   const {
@@ -60,6 +60,7 @@ export const useNotes = () => {
   } = useQuery<Note[]>({
     queryKey: ['notes'],
     queryFn: fetchNotes,
+    initialData: initialNotes,
   });
 
   const addNoteMutation = useMutation({

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,49 +1,19 @@
 // app/page.tsx
-'use client';
+import { getAllNotes } from '@/lib/noteService';
+import { NoteContainer } from './NoteContainer';
+import { Note } from './hooks/useNotes';
 
-import { NewNoteForm } from '@/components/notes/NewNoteForm';
-import { NoteCard } from '@/components/notes/NoteCard';
-import { Note, useNotes } from './hooks/useNotes';
-
-const NotePage = () => {
-  const {
-    notes,
-    isLoading,
-    isError,
-    addNote,
-    isAdding,
-    updateNote,
-    isUpdating,
-    deleteNote,
-    isDeleting,
-  } = useNotes();
-
-  if (isLoading) return <div className="text-center p-10">読み込み中...</div>;
-  if (isError)
-    return (
-      <div className="text-center p-10 text-red-500">
-        エラーが発生しました。
-      </div>
-    );
+const NotePage = async () => {
+  const notesFromDb = await getAllNotes('1');
+  const initialNotes: Note[] = notesFromDb.map((note) => ({
+    ...note,
+    createdAt: note.createdAt.toISOString(),
+  }));
 
   return (
     <main className="container mx-auto mt-10 max-w-4xl">
       <h1 className="text-3xl font-bold text-center mb-6">Note App</h1>
-
-      <NewNoteForm addNote={addNote} isAdding={isAdding} />
-
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-        {notes?.map((note: Note) => (
-          <NoteCard
-            key={note.id}
-            note={note}
-            updateNote={updateNote}
-            isUpdating={isUpdating}
-            deleteNote={deleteNote}
-            isDeleting={isDeleting}
-          />
-        ))}
-      </div>
+      <NoteContainer initialNotes={initialNotes} />
     </main>
   );
 };


### PR DESCRIPTION
### 【チケット番号】
Closes NJT-41

### 【概要】
- 初期ページのサーバーコンポーネント化
- 初回フェッチ効率化

### 【修正内容】
- `page.tsx`で行っていたクライアント処理を`NoteContainer.tsx`に切り出した
- これにより`page.tsx`をサーバーコンポーネント化することができた
- これによりAPIエンドポイントにアクセスせず、直接DBへフェッチを行う`getAllNotes`を呼び出すことが出来るようになった
- これにより初回データ取得が高速化することができた