### PR TITLE
[refactor] NJT-42 Note型の切り出し

### DIFF
--- a/app/NoteContainer.tsx
+++ b/app/NoteContainer.tsx
@@ -1,8 +1,9 @@
 // app/NoteContainer.tsx
 'use client';
 
+import { Note } from '@/types';
 import { NewNoteForm } from '@/components/notes/NewNoteForm';
-import { Note, useNotes } from './hooks/useNotes';
+import { useNotes } from './hooks/useNotes';
 import { NoteCard } from '@/components/notes/NoteCard';
 
 type NoteContainerProps = {

--- a/app/hooks/useNotes.ts
+++ b/app/hooks/useNotes.ts
@@ -1,13 +1,7 @@
 // app/hooks/useNotes.ts
+import { Note } from '@/types';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
-
-export type Note = {
-  id: number;
-  title: string;
-  content: string;
-  createdAt: string;
-};
 
 const fetchNotes = async (): Promise<Note[]> => {
   const res = await fetch('api/notes');

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,3 +1,4 @@
+// app/layout.tsx
 import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
 import './globals.css';

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,7 @@
 // app/page.tsx
 import { getAllNotes } from '@/lib/noteService';
 import { NoteContainer } from './NoteContainer';
-import { Note } from './hooks/useNotes';
+import { Note } from '@/types';
 
 const NotePage = async () => {
   const notesFromDb = await getAllNotes('1');

--- a/components/Providers.tsx
+++ b/components/Providers.tsx
@@ -1,3 +1,4 @@
+// components/ui/Providers.tsx
 'use client';
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';

--- a/components/notes/NoteCard.tsx
+++ b/components/notes/NoteCard.tsx
@@ -16,7 +16,7 @@ import { Textarea } from '../ui/textarea';
 import { Button } from '../ui/button';
 import { Loader2, Pencil, Trash2 } from 'lucide-react';
 
-import { Note } from '@/app/hooks/useNotes';
+import { Note } from '@/types';
 
 type NoteCardProps = {
   note: Note;

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,3 +1,4 @@
+// lib/prisma.ts
 import { PrismaClient } from '@prisma/client';
 
 // PrismaClientのインスタンスをグローバルに宣言

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,6 +1,7 @@
-import { clsx, type ClassValue } from "clsx"
-import { twMerge } from "tailwind-merge"
+// lib/utils.ts
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
+  return twMerge(clsx(inputs));
 }

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,0 +1,3 @@
+// types/index.ts
+export * from './user';
+export * from './note';

--- a/types/note.ts
+++ b/types/note.ts
@@ -1,0 +1,7 @@
+// types/note.ts
+export type Note = {
+  id: number;
+  title: string;
+  content: string;
+  createdAt: string;
+};

--- a/types/user.ts
+++ b/types/user.ts
@@ -1,3 +1,4 @@
+// types/user.ts
 export interface User {
   userId: string;
   email: string;


### PR DESCRIPTION
### 【チケット番号】
Closes NJT-42

### 【概要】
Note型の定義場所の変更

### 【修正内容】
- `useNotes.ts`で定義されていた`Note`型定義を切り出し、`types`フォルダへ移動した
- すでに定義していた`user.ts`の型定義と併せてエキスポートを行う`index.ts`を定義した