### PR TITLE
[refactor] NJT-54 新規ノート作成フォームの画像選択でのドロップ機能実装

### DIFF
--- a/app/notes/components/NewNoteForm.tsx
+++ b/app/notes/components/NewNoteForm.tsx
@@ -41,7 +41,7 @@ export const NewNoteForm = ({ addNote, isAdding }: NewNoteFormProps) => {
     onDrop,
     accept: { 'image/*': [] },
     multiple: false,
-    noClick: true, // `open`関数でクリックを制御するためtrueに
+    noClick: false, // `open`関数でクリックを許可するために`false`に
     noKeyboard: true,
   });
 

--- a/app/notes/components/NewNoteForm.tsx
+++ b/app/notes/components/NewNoteForm.tsx
@@ -1,7 +1,8 @@
 // app/notes/components/NewNoteForm.tsx
 'use client';
 
-import { useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { default as NextImage } from 'next/image';
 import {
   Card,
   CardContent,
@@ -12,7 +13,8 @@ import {
 import { Input } from '@/app/components/ui/input';
 import { Textarea } from '@/app/components/ui/textarea';
 import { Button } from '@/app/components/ui/button';
-import { Loader2 } from 'lucide-react';
+import { Loader2, UploadCloud } from 'lucide-react';
+import { useDropzone } from 'react-dropzone';
 
 type NewNoteFormProps = {
   addNote: (formData: FormData) => void;
@@ -21,20 +23,64 @@ type NewNoteFormProps = {
 
 export const NewNoteForm = ({ addNote, isAdding }: NewNoteFormProps) => {
   const formRef = useRef<HTMLFormElement>(null);
+  const [imageFile, setImageFile] = useState<File | null>(null);
+  const [preview, setPreview] = useState<string | null>(null);
+
+  // ファイルがドロップされたときの処理
+  const onDrop = useCallback((acceptedFiles: File[]) => {
+    if (acceptedFiles && acceptedFiles[0]) {
+      const file = acceptedFiles[0];
+      setImageFile(file);
+      // プレビュー用のURLを生成
+      setPreview(URL.createObjectURL(file));
+    }
+  }, []);
+
+  // react-dropzoneのセットアップ
+  const { getRootProps, getInputProps, isDragActive, open } = useDropzone({
+    onDrop,
+    accept: { 'image/*': [] },
+    multiple: false,
+    noClick: true, // `open`関数でクリックを制御するためtrueに
+    noKeyboard: true,
+  });
+
+  // プレビューURLのメモリリークを防ぐためのクリーンアップ
+  useEffect(() => {
+    if (!preview || !preview.startsWith('blob:')) {
+      return;
+    }
+
+    return () => {
+      URL.revokeObjectURL(preview);
+    };
+  }, [preview]);
+
+  // フォームの送信処理
+  const handleFormSubmit = (formData: FormData) => {
+    // 状態に保持している画像ファイルがあれば、FormDataに追加
+    if (imageFile) {
+      formData.set('image', imageFile);
+    }
+    addNote(formData);
+    // フォームと状態をリセット
+    formRef.current?.reset();
+    setImageFile(null);
+    setPreview(null);
+  };
+
+  // プレビューをクリアする処理
+  const handleClearPreview = () => {
+    setImageFile(null);
+    setPreview(null);
+  };
 
   return (
     <Card className="mb-10">
       <CardHeader>
         <CardTitle>新しいノートの作成</CardTitle>
       </CardHeader>
-      <form
-        ref={formRef}
-        action={(formData) => {
-          addNote(formData);
-          formRef.current?.reset();
-        }}
-        className="space-y-4"
-      >
+      <form ref={formRef} action={handleFormSubmit} className="space-y-4">
         <CardContent className="space-y-4">
           <Input
             name="title"
@@ -49,17 +95,54 @@ export const NewNoteForm = ({ addNote, isAdding }: NewNoteFormProps) => {
             required
           />
           <div>
-            <label htmlFor="image" className="text-sm font-medium">
-              画像
-            </label>
-            <Input
-              id="image"
-              name="image"
-              type="file"
-              accept="image/*"
-              disabled={isAdding}
-              className="mt-1"
-            />
+            <label className="text-sm font-medium">画像</label>
+            <div
+              {...getRootProps()}
+              className={`mt-1 border-2 border-dashed rounded-lg p-4 text-center transition-colors
+                ${isDragActive ? 'border-blue-500 bg-blue-50' : 'border-gray-300'}
+                ${preview ? 'h-48' : 'h-24'} flex items-center justify-center relative`}
+            >
+              {/* inputは非表示だが、dropzoneのために必要 */}
+              <input {...getInputProps()} />
+
+              {preview ? (
+                <NextImage
+                  src={preview}
+                  alt="プレビュー"
+                  fill
+                  className="object-contain rounded-md"
+                  sizes="100vw"
+                />
+              ) : (
+                <div className="text-gray-500">
+                  <UploadCloud className="mx-auto h-8 w-8" />
+                  <p>画像をドラッグ＆ドロップ</p>
+                  <p className="text-xs">または下のボタンからファイルを選択</p>
+                </div>
+              )}
+            </div>
+            <div className="mt-2 flex items-center justify-end gap-2">
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                onClick={open}
+                disabled={isAdding}
+              >
+                画像を選択
+              </Button>
+              {preview && (
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="destructive"
+                  onClick={handleClearPreview}
+                  disabled={isAdding}
+                >
+                  画像をクリア
+                </Button>
+              )}
+            </div>
           </div>
         </CardContent>
         <CardFooter>


### PR DESCRIPTION
### 【チケット番号】
Closes NJT-54

### 【概要】
新規ノート作成フォームの画像選択でのドロップ機能実装

### 【修正内容】
- 既存の画像選択方法だけではなく、`dropzone`を利用したドロップ方式でも画像アップロードが可能になるように修正を行った
- アンマウント時にはメモリリークを防ぐためクリーンアップ処理で`preview`のオブジェクトURLを削除する