### PR TITLE
[fix] NJT-71 ビルドコンパイル時のエラー修正（detailPageProps）

### DIFF
--- a/app/notes/[id]/page.tsx
+++ b/app/notes/[id]/page.tsx
@@ -14,6 +14,7 @@ type detailPageProps = {
   params: {
     id: string;
   };
+  searchParams: { [key: string]: string | string[] | undefined };
 };
 
 export const generateMetadata = async ({


### PR DESCRIPTION
### 【チケット番号】
Closes NJT-71

### 【概要】
- ビルドコンパイル時のエラー修正
  - `detailPageProps`

### 【修正内容】
- `detailPageProps`が`Next.js`が内部で使っている`PageProps`と互換性がないためエラーが出ていた
- 欠けていたクエリパラメータ`searchParams`を追加した