### PR TITLE
[fix] NJT-72 ビルドエラーの修正(detailPageProps)

### DIFF
--- a/app/notes/[id]/page.tsx
+++ b/app/notes/[id]/page.tsx
@@ -11,10 +11,7 @@ import { Suspense } from 'react';
 import { default as NextImage } from 'next/image';
 
 type detailPageProps = {
-  params: {
-    id: string;
-  };
-  searchParams: { [key: string]: string | string[] | undefined };
+  params: Promise<{ id: string }>;
 };
 
 export const generateMetadata = async ({


### PR DESCRIPTION
### 【チケット番号】
Closes NJT-72

### 【概要】
ビルドエラーの修正(`detailPageProps`)

### 【修正内容】
- `Next.js ver15.4.3`では`Dynamic Route`の`params`プロパティは`Promise`型になったため、従来の同期的な書き方では`TypeScript`エラーが発生する
- そのため、`detailPageProps`の`params`プロパティを`Promise`型とした
- 前回の修正で追加した`searchParams`は不要なため削除した