### PR TITLE
[feature] NJT-74 タイトル・内容の入力フォームのバリデーションチェック処理の拡張

### DIFF
--- a/app/notes/components/NoteCard.tsx
+++ b/app/notes/components/NoteCard.tsx
@@ -39,8 +39,11 @@ export const NoteCard = ({
     onDrop,
     handleClearImage,
     handleCancel,
-    handleFormAction,
     setIsEditing,
+    register,
+    handleSubmit,
+    onSubmit,
+    errors,
   } = useNoteCard({ note, updateNote });
 
   if (isEditing) {
@@ -52,7 +55,10 @@ export const NoteCard = ({
         onDrop={onDrop}
         handleClearImage={handleClearImage}
         handleCancel={handleCancel}
-        handleFormAction={handleFormAction}
+        register={register}
+        handleSubmit={handleSubmit}
+        onSubmit={onSubmit}
+        errors={errors}
       />
     );
   }
@@ -60,8 +66,8 @@ export const NoteCard = ({
   return (
     <Card className="flex flex-col h-full">
       <CardHeader>
-        <Link href={`/notes/${note.id}`} className="hover:underline">
-          <CardTitle>{note.title}</CardTitle>
+        <Link href={`/notes/${note.id}`} className="hover:underline min-w-0">
+          <CardTitle className="truncate">{note.title}</CardTitle>
         </Link>
         <CardDescription>
           {new Date(note.createdAt).toLocaleString('ja-JP')}

--- a/app/notes/components/NoteEditForm.tsx
+++ b/app/notes/components/NoteEditForm.tsx
@@ -2,6 +2,13 @@
 'use client';
 
 import { default as NextImage } from 'next/image';
+import type {
+  UseFormRegister,
+  FieldErrors,
+  UseFormHandleSubmit,
+} from 'react-hook-form';
+import { useDropzone } from 'react-dropzone';
+
 import {
   Card,
   CardContent,
@@ -12,9 +19,9 @@ import { Input } from '@/app/components/ui/input';
 import { Button } from '@/app/components/ui/button';
 import { Textarea } from '@/app/components/ui/textarea';
 import { Loader2, UploadCloud } from 'lucide-react';
-import { useDropzone } from 'react-dropzone';
 
 import { Note } from '@/types';
+import type { NoteFormInput } from '@/lib/validators';
 
 type NoteEditFormProps = {
   note: Note;
@@ -23,7 +30,10 @@ type NoteEditFormProps = {
   onDrop: (acceptedFiles: File[]) => void;
   handleClearImage: () => void;
   handleCancel: () => void;
-  handleFormAction: (formData: FormData) => void;
+  register: UseFormRegister<NoteFormInput>;
+  handleSubmit: UseFormHandleSubmit<NoteFormInput>;
+  onSubmit: (data: NoteFormInput) => void;
+  errors: FieldErrors<NoteFormInput>;
 };
 
 export const NoteEditForm = ({
@@ -33,7 +43,10 @@ export const NoteEditForm = ({
   onDrop,
   handleClearImage,
   handleCancel,
-  handleFormAction,
+  register,
+  handleSubmit,
+  onSubmit,
+  errors,
 }: NoteEditFormProps) => {
   const { getRootProps, getInputProps, isDragActive, open } = useDropzone({
     onDrop,
@@ -42,26 +55,46 @@ export const NoteEditForm = ({
     noClick: false, // Dropzone自体をクリックしてもダイアログが開かないようにする
     noKeyboard: true, // キーボード操作でもダイアログが開かないようにする
   });
+
   return (
     <Card className="flex flex-col h-full">
-      <form action={handleFormAction} className="flex flex-col flex-grow gap-4">
+      <form
+        onSubmit={handleSubmit(onSubmit)}
+        className="flex flex-col flex-grow gap-4"
+      >
         <CardHeader>
-          <Input
-            name="title"
-            defaultValue={note.title}
-            className="text-lg font-bold"
-            disabled={isUpdating}
-            required
-          />
+          <div>
+            <Input
+              {...register('title')}
+              placeholder="タイトル"
+              defaultValue={note.title}
+              className="text-lg font-bold"
+              disabled={isUpdating}
+              aria-invalid={errors.title ? 'true' : 'false'}
+            />
+            {errors.title && (
+              <p className="mt-1 text-sm text-red-500">
+                {errors.title.message}
+              </p>
+            )}
+          </div>
         </CardHeader>
         <CardContent className="flex-grow">
-          <Textarea
-            name="content"
-            defaultValue={note.content}
-            className="whitespace-pre-wrap min-h-[100px]"
-            disabled={isUpdating}
-            required
-          />
+          <div>
+            <Textarea
+              {...register('content')}
+              placeholder="内容"
+              defaultValue={note.content}
+              className="whitespace-pre-wrap min-h-[100px]"
+              disabled={isUpdating}
+              aria-invalid={errors.content ? 'true' : 'false'}
+            />
+            {errors.content && (
+              <p className="mt-1 text-sm text-red-500">
+                {errors.content.message}
+              </p>
+            )}
+          </div>
           <div>
             <label className="text-sm font-medium">画像</label>
             <div

--- a/app/notes/hooks/useNoteCard.ts
+++ b/app/notes/hooks/useNoteCard.ts
@@ -4,6 +4,10 @@
 import { Note } from '@/types';
 import { useState, useEffect, useCallback } from 'react';
 
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { noteSchema, NoteFormInput } from '@/lib/validators';
+
 type UseNoteCardProps = {
   note: Note;
   updateNote: (variables: { id: number; formData: FormData }) => void;
@@ -17,6 +21,20 @@ export const useNoteCard = ({ note, updateNote }: UseNoteCardProps) => {
   const [imageAction, setImageAction] = useState<'keep' | 'clear' | 'update'>(
     'keep',
   );
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    reset,
+  } = useForm<NoteFormInput>({
+    resolver: zodResolver(noteSchema),
+    // フォームの初期値を設定
+    defaultValues: {
+      title: note.title,
+      content: note.content,
+    },
+  });
 
   // 編集モード開始/終了時の処理
   useEffect(() => {
@@ -62,10 +80,20 @@ export const useNoteCard = ({ note, updateNote }: UseNoteCardProps) => {
 
   const handleCancel = () => {
     setIsEditing(false);
+
+    reset({
+      title: note.title,
+      content: note.content,
+    });
   };
 
   // フォーム送信時に新しいFileオブジェクトをFormDataに追加する
-  const handleFormAction = (formData: FormData) => {
+  const onSubmit = (data: NoteFormInput) => {
+    const formData = new FormData();
+    formData.append('title', data.title);
+    formData.append('content', data.content);
+    formData.append('imageAction', imageAction);
+
     if (imageAction === 'update' && newImageFile) {
       formData.set('image', newImageFile);
     } else {
@@ -84,7 +112,10 @@ export const useNoteCard = ({ note, updateNote }: UseNoteCardProps) => {
     onDrop,
     handleClearImage,
     handleCancel,
-    handleFormAction,
     setIsEditing,
+    register,
+    handleSubmit,
+    errors,
+    onSubmit,
   };
 };

--- a/lib/image.service.test.ts
+++ b/lib/image.service.test.ts
@@ -81,6 +81,11 @@ describe('image.service.ts:saveImageAndGetPath', () => {
 
   // --- 4. アップロードに失敗する場合 ---
   it('画像のアップロードに失敗した場合、エラーをスローする', async () => {
+    // このテストではconsole.errorが意図的に呼ばれるため、出力を一時的に無効化する
+    const mockConsoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
     const testFile = new File(['dummy content'], 'failure.png');
     const uploadError = new Error('Supabase upload failed');
 
@@ -96,6 +101,9 @@ describe('image.service.ts:saveImageAndGetPath', () => {
     );
 
     expect(mockUpload).toHaveBeenCalled();
+
+    // 無効化したconsole.errorを元の状態に戻す
+    mockConsoleError.mockRestore();
   });
 });
 
@@ -131,6 +139,11 @@ describe('image.service.ts:getSignedUrl', () => {
 
   // --- 6. 署名付きURLの生成に失敗する場合 ---
   it('署名付きURLの生成に失敗した場合、nullを返す', async () => {
+    // このテストではconsole.errorが意図的に呼ばれるため、出力を一時的に無効化する
+    const mockConsoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
     const mockFilePath = 'images/mock-path/test.png';
     const signedUrlError = new Error('Signed URL creation failed');
 
@@ -142,6 +155,9 @@ describe('image.service.ts:getSignedUrl', () => {
     const result = await getSignedUrl(mockFilePath);
 
     expect(result).toBeNull();
+
+    // 無効化したconsole.errorを元の状態に戻す
+    mockConsoleError.mockRestore();
   });
 
   // --- 7. ファイルがnullの場合 ---

--- a/lib/validators.ts
+++ b/lib/validators.ts
@@ -11,7 +11,7 @@ export const noteSchema = z.object({
   content: z
     .string()
     .min(1, { message: '内容は必須です。' })
-    .max(300, { message: '内容は1000文字以内で入力してください。' }),
+    .max(300, { message: '内容は300文字以内で入力してください。' }),
 });
 
 export type NoteFormInput = z.infer<typeof noteSchema>;

--- a/lib/validators.ts
+++ b/lib/validators.ts
@@ -1,0 +1,17 @@
+// lib/validators.ts
+import { z } from 'zod';
+
+// ノート作成・編集フォーム用のバリデーションスキーマ
+export const noteSchema = z.object({
+  title: z
+    .string()
+    .min(1, { message: 'タイトルは必須です。' })
+    .max(30, { message: 'タイトルは30文字以内で入力してください。' }),
+
+  content: z
+    .string()
+    .min(1, { message: '内容は必須です。' })
+    .max(300, { message: '内容は1000文字以内で入力してください。' }),
+});
+
+export type NoteFormInput = z.infer<typeof noteSchema>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@auth0/nextjs-auth0": "^4.8.0",
+        "@hookform/resolvers": "^5.2.1",
         "@radix-ui/react-checkbox": "^1.3.2",
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-slot": "^1.2.3",
@@ -23,10 +24,11 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-dropzone": "^14.3.8",
+        "react-hook-form": "^7.62.0",
         "sonner": "^2.0.6",
         "tailwind-merge": "^3.3.1",
         "validator": "^13.15.15",
-        "zod": "^4.0.15"
+        "zod": "^4.0.17"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -1250,6 +1252,18 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.2.1.tgz",
+      "integrity": "sha512-u0+6X58gkjMcxur1wRWokA7XsiiBJ6aK17aPZxhkoYiK5J+HcTx0Vhu9ovXe6H+dVpO6cjrn2FkJTryXEMlryQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -2945,6 +2959,12 @@
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
       "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@supabase/auth-js": {
@@ -9071,6 +9091,22 @@
         "react": ">= 16.8 || 18.0.0"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.62.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.62.0.tgz",
+      "integrity": "sha512-7KWFejc98xqG/F4bAxpL41NB3o1nnvQO1RWZT3TqRZYL8RryQETGfEdVnJN2fy1crCiBLLjkRBVK05j24FxJGA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -11235,9 +11271,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.0.15",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.0.15.tgz",
-      "integrity": "sha512-2IVHb9h4Mt6+UXkyMs0XbfICUh1eUrlJJAOupBHUhLRnKkruawyDddYRCs0Eizt900ntIMk9/4RksYl+FgSpcQ==",
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.0.17.tgz",
+      "integrity": "sha512-1PHjlYRevNxxdy2JZ8JcNAw7rX8V9P1AKkP+x/xZfxB0K5FYfuV+Ug6P/6NVSR2jHQ+FzDDoDHS04nYUsOIyLQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@auth0/nextjs-auth0": "^4.8.0",
+    "@hookform/resolvers": "^5.2.1",
     "@radix-ui/react-checkbox": "^1.3.2",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-slot": "^1.2.3",
@@ -31,10 +32,11 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-dropzone": "^14.3.8",
+    "react-hook-form": "^7.62.0",
     "sonner": "^2.0.6",
     "tailwind-merge": "^3.3.1",
     "validator": "^13.15.15",
-    "zod": "^4.0.15"
+    "zod": "^4.0.17"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,6 +13,15 @@ export default defineConfig({
     setupFiles: './tests/setup.ts',
     // CSSファイルのインポートをモックする設定（テスト実行速度の向上）
     css: true,
+    exclude: [
+      '**/node_modules/**',
+      '**/dist/**',
+      '**/cypress/**',
+      '**/.{idea,git,cache,output,temp}/**',
+      '**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build,playwright}.config.*',
+      // PlaywrightのE2Eテストフォルダを除外
+      '**/e2e/**',
+    ],
   },
   // tsconfig.jsonのパスエイリアス（例: @/*）をVitestに認識させる設定
   resolve: {


### PR DESCRIPTION
### 【チケット番号】
Closes NJT-74

### 【概要】
タイトル・内容の入力フォームのバリデーションチェック処理の拡張
（最大文字数の実装）

### 【修正内容】
- `NewNoteForm.tsx`と`NoteEditForm.tsx`で行っているタイトルと内容の入力フォームにバリデーションチェック処理の拡張を行った
- バリデーションチェックには`react-hook-form`と`Zod`を利用した
- バリデーションチェック処理用のモジュール`validator.ts`を新規作成した
- タイトルは30文字以内、内容は300文字以内とした
- 各モジュールのテストコードも修正を行った